### PR TITLE
Show the difference of using `mapDispathToProps()`

### DIFF
--- a/demo-apps/react-redux-router-es6/src/components/App.js
+++ b/demo-apps/react-redux-router-es6/src/components/App.js
@@ -6,7 +6,6 @@ import HomePage from './home/HomePage';
 import EventsPage from './events/EventsPage';
 import AboutPage from './about/AboutPage';
 import Header from './common/Header';
-// import ManageCoursePage from './course/ManageCoursePage'; //eslint-disable-line import/no-named-as-default
 import { connect } from 'react-redux';
 
 class App extends React.Component {
@@ -20,10 +19,6 @@ class App extends React.Component {
 				<Route exact path="/" component={HomePage} />
 				<Route path="/about" component={AboutPage} />
 				<Route path="/events" component={EventsPage} />
-
-				{/* <Route path="/courses" component={CoursesPage} />
-				<Route path="/course/:id" component={ManageCoursePage} />
-				<Route path="/course" component={ManageCoursePage} exact /> */}
 			</div>
 		);
 	}

--- a/demo-apps/react-redux-router-es6/src/components/events/EventsPage.js
+++ b/demo-apps/react-redux-router-es6/src/components/events/EventsPage.js
@@ -24,8 +24,8 @@ class EventsPage extends Component {
 	}
 
 	onClickSave() {
-		// dispatch our action
-		this.props.dispatch(driftEventActions.createDriftEvent(this.state.driftEvent));
+		// dispatch - cleaner way.
+		this.props.createDriftEvent(this.state.driftEvent);
 	}
 
 	driftEventsRow(driftEvent, index) {
@@ -50,12 +50,19 @@ function mapStateToProps(state, ownProps) {
 	};
 }
 
+// What actions are available in our Component?
+function mapDispatchToProps(dispatch) {
+	return {
+		createDriftEvent: driftEvent => dispatch(driftEventActions.createDriftEvent(driftEvent))
+	};
+}
+
 EventsPage.propTypes = {
-	dispatch: PropTypes.func.isRequired,
-	driftEvents: PropTypes.array.isRequired
+	driftEvents: PropTypes.array.isRequired,
+	createDriftEvent: PropTypes.func.isRequired,
 };
 
-export default connect(mapStateToProps)(EventsPage);
+export default connect(mapStateToProps, mapDispatchToProps)(EventsPage);
 
 /**
  * Lets talk about exports


### PR DESCRIPTION
Using `mapDishpatchToProps()` instead of using the dipatch call directly
is quite a bit cleaner, however there are some things to note:

1. Dispatch is no longer being injected into our component so we must
make sure we call dispatch inside of our mapDispatchToProps function.
2. No longer need to call dispatch directly in onClickSave

Next, we will demo using `bindActionCreators()`